### PR TITLE
group repositories need to be created last - renamed the script

### DIFF
--- a/zzz_public.json
+++ b/zzz_public.json
@@ -1,5 +1,5 @@
 {
-  "name": "public",
+  "name": "zzz_public",
   "type": "groovy",
   "content": "repository.createMavenGroup('public', ['fuse','jboss','jenkins-ci','maven-central','maven-public','maven-releases','maven-snapshots','sonatype-snapshots','sonatype-staging'])"
 }


### PR DESCRIPTION
The script to create group repositories need to be executed last as it depends on the other repositories being created before.

Just renamed the script.

At some point would be nice to refactor postStart.sh to make this more clear and explicit.
