### PR TITLE
Add `jboss.ea` repository to public group

### DIFF
--- a/nexus.xml
+++ b/nexus.xml
@@ -290,6 +290,7 @@
           <memberRepository>central</memberRepository>
           <memberRepository>staging</memberRepository>
           <memberRepository>jboss</memberRepository>
+          <memberRepository>jboss.ea</memberRepository>
           <memberRepository>fuse</memberRepository>
           <memberRepository>sonatype-snapshots</memberRepository>
           <memberRepository>sonatype-staging</memberRepository>


### PR DESCRIPTION
This adds `jboss.ea` repository, the JBoss Early Access repository to
public group in order to make the early access builds available.